### PR TITLE
feat: add github PR labeler automation 

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,44 @@
+ci/cd:
+  - changed-files:
+      - any-glob-to-any-file:
+          - .github/*
+          - .github/**/*
+
+documentation:
+  - changed-files:
+      - any-glob-to-any-file:
+          - "**/*.md"
+
+mail:
+  - changed-files:
+      - any-glob-to-any-file:
+          - services/mail/*
+          - services/mail/**/*
+
+form:
+  - changed-files:
+      - any-glob-to-any-file:
+          - services/form/*
+          - services/form/**/*
+          - frontend/form/*
+          - frontend/form/**/*
+
+event:
+  - changed-files:
+      - any-glob-to-any-file:
+          - services/event/*
+          - services/event/**/*
+          - frontend/event/*
+          - frontend/event/**/*
+
+backend:
+  - changed-files:
+      - any-glob-to-any-file:
+          - services/*
+          - services/**/*
+
+frontend:
+  - changed-files:
+      - any-glob-to-any-file:
+          - frontend/*
+          - frontend/**/*


### PR DESCRIPTION
Introduces .github/labeler.yml to automate labeling of pull requests based on file changes. Labels include ci/cd, documentation, mail, form, event, backend, and frontend, improving workflow organization.

## What does this PR do?

A brief description of changes.

## Related Issue

Closes #

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other:

## Checklist

- [ ] Code follows project conventions
- [ ] I tested my changes locally
- [ ] Linting passes
- [ ] I added @seberatolmez and @dogukanurker as reviewers

