### PR TITLE
feat(email): add AI TALKS'25 email template

### DIFF
--- a/scripts/mails/ai-talks-email.html
+++ b/scripts/mails/ai-talks-email.html
@@ -16,60 +16,49 @@
     .container { max-width:600px; }
     .content { padding:34px 40px 26px 40px; }
 
-    .card{
-      background-color:#ffffff;
-      border-radius:12px;
-      box-shadow:0 8px 30px rgba(0,0,0,0.10);
-      overflow:hidden;
-    }
+   .card{
+  background-color:#ffffff;
+  border-radius:14px;
+  border:none; 
+  box-shadow:0 12px 36px rgba(185,28,28,0.22); 
+  overflow:hidden;
+}
 
     .section-title{
-      margin:0 0 12px 0;
-      font-size:18px;
-      color:#111827;
+      margin:0 0 14px 0;
+      font-size:22px; 
+      color:#B91C1C; 
       font-weight:700;
     }
 
-    .muted{ color:#6b7280; }
-
-    .list-box{
-      border:1px solid #eddee2;
-      background-color:#fff5f8;
-      border-radius:12px;
-    }
-
-    .event-details-box{
-      border:1px solid #e5e7eb;
-      border-radius:12px;
-      background-color:#ffffff;
-    }
-
-    
+    .muted{ color:#4b5563; font-size:16.5px; line-height:24px; } 
+.list-box{
+  border:2px solid #B91C1C;              
+  background-color:#FEE2E2;              
+  border-radius:14px;
+}
+.event-details-box{
+  border:2px solid #B91C1C;            
+  border-radius:14px;
+  background-color:#ffffff;
+}
     .speaker-photo{
       display:block;
-      width:72px;
-      height:72px;
+      width:80px;
+      height:80px;
       border-radius:50%;
-      border:4px solid #ffffff;
-      box-shadow:0 6px 18px rgba(0,0,0,0.16);
+      border:3px solid #B91C1C; 
+      box-shadow:0 6px 18px rgba(185, 28, 28, 0.2);
       object-fit:cover;
-      object-position:center top;
     }
-
-    
-    .note-cert{
-  background-color:#ffffff;
-  border:none;               
-  border-radius:12px;
-}
    
     .note-line{
-  font-size:14px;
-  line-height:22px;
-  color:#0f766e;   
-  font-weight:600;
-  margin:0;
-}
+      font-size:17px; 
+      line-height:26px;
+      color:#B91C1C; 
+      font-weight:700;
+      margin:0;
+    }
 
     @media screen and (max-width:600px){
       .container{ width:100% !important; border-radius:0 !important; }
@@ -81,177 +70,142 @@
 <body style="margin:0; padding:0; background-color:#f0f2f5;">
   <table role="presentation" width="100%" cellspacing="0" cellpadding="0" border="0">
     <tr>
-      <td align="center" style="padding:20px 0;">
-        <table class="container card" role="presentation" width="600" cellspacing="0" cellpadding="0" border="0">
+     <td align="center" style="padding:0;">
 
-      
-          <tr>
-            <td style="line-height:0; font-size:0;">
-              <img
-                src="https://raw.githubusercontent.com/GDG-Yasar-Software-Team/mail-assets/main/ai-talks-25/ai-talks-25ai-talks-email-banner.png"
-                alt="AI TALKS'25 Banner"
-                width="600"
-                style="display:block; width:100%; max-width:600px; height:auto; margin:0; padding:0;"
-              />
-            </td>
-          </tr>
-
-   
+        <table class="container card" role="presentation" width="600" cellspacing="0" cellpadding="0" border="0"
+  style="border-collapse:collapse; mso-table-lspace:0pt; mso-table-rspace:0pt;">
+<tr>
+  <td style="padding:0; margin:0; line-height:0; font-size:0;">
+    <img
+      src="https://raw.githubusercontent.com/GDG-Yasar-Software-Team/mail-assets/main/ai-talks-25/ai-talks-25ai-talks-email-banner.jpg"
+      alt="AI TALKS'25 Banner"
+      width="600"
+      style="display:block; width:600px; max-width:600px; height:auto; border:0; margin:0; padding:0; line-height:0; font-size:0;"
+    />
+  </td>
+</tr>
           <tr>
             <td class="content">
 
-              <h1 style="margin:0 0 10px 0; font-size:26px; font-weight:700; color:#111827; text-align:center;">
+              <h1 style="margin:0 0 12px 0; font-size:30px; font-weight:700; color:#B91C1C; text-align:center;">
                 AI TALKS’25: Yapay Zeka ile Geleceği Yakala 🤖✨
               </h1>
 
-              <p style="margin:0 0 20px 0; font-size:15.5px; line-height:26px; color:#4b5563; text-align:center;">
+              <p style="margin:0 0 28px 0; font-size:18.5px; line-height:30px; color:#374151; text-align:center;">
                 26 Aralık’ta güncel AI trendlerini ve gerçek dünya uygulamalarını sektör profesyonellerinden dinle.
               </p>
 
-           
               <table role="presentation" width="100%" cellspacing="0" cellpadding="0" border="0"
-                     class="list-box" style="margin-bottom:22px;">
+                     class="list-box" style="margin-bottom:24px;">
                 <tr>
-                  <td style="padding:18px 18px; border-radius:12px;">
-                    <p style="margin:0 0 10px 0; font-size:16px; color:#0f0808; font-weight:800;">
+                  <td style="padding:22px 24px; border-radius:12px;">
+                    <p style="margin:0 0 12px 0; font-size:19px; color:#B91C1C; font-weight:800;">
                       🎯 Etkinlik Kapsamı
                     </p>
-                    <ul style="margin:0; padding-left:18px; font-size:15px; color:#111827; line-height:26px;">
-                      <li style="margin-bottom:6px;">MLOps & Büyük Ölçekte Üretime Alma</li>
-                      <li style="margin-bottom:6px;">Gerçek Zamanlı AI Mimarileri</li>
-                      <li style="margin-bottom:6px;">Öneri Sistemleri & Kişiselleştirme</li>
+                    <ul style="margin:0; padding-left:24px; font-size:17px; color:#111827; line-height:30px;">
+                      <li style="margin-bottom:8px;">MLOps & Büyük Ölçekte Üretime Alma</li>
+                      <li style="margin-bottom:8px;">Gerçek Zamanlı AI Mimarileri</li>
+                      <li style="margin-bottom:8px;">Öneri Sistemleri & Kişiselleştirme</li>
                       <li style="margin-bottom:0;">Kurumsal GenAI: RAG & Ajan Sistemleri</li>
                     </ul>
                   </td>
                 </tr>
               </table>
 
-             
               <table role="presentation" width="100%" cellspacing="0" cellpadding="0" border="0"
-                     class="event-details-box" style="margin-bottom:14px;">
+                     class="event-details-box" style="margin-bottom:18px;">
                 <tr>
-                  <td style="padding:20px 20px;">
-                    <p class="section-title" style="margin:0 0 14px 0;">📌 Etkinlik Bilgileri</p>
+                  <td style="padding:22px 22px;">
+                    <p class="section-title">📌 Etkinlik Bilgileri</p>
 
-                    <table role="presentation" width="100%" cellspacing="0" cellpadding="0" border="0" style="margin-bottom:10px;">
+                    <table role="presentation" width="100%" cellspacing="0" cellpadding="0" border="0" style="margin-bottom:14px;">
                       <tr>
-                        <td width="28" valign="top" style="font-size:20px;">🗓️</td>
-                        <td style="font-size:15px; color:#111827; line-height:24px;">
-                          <strong>Tarih:</strong> 26 Aralık 2025
+                        <td width="38" valign="top" style="font-size:24px;">🗓️</td>
+                        <td style="font-size:17px; color:#111827; line-height:28px;">
+                          <strong style="color:#B91C1C;">Tarih:</strong> 26 Aralık 2025
                         </td>
                       </tr>
                     </table>
 
-                    <table role="presentation" width="100%" cellspacing="0" cellpadding="0" border="0" style="margin-bottom:10px;">
+                    <table role="presentation" width="100%" cellspacing="0" cellpadding="0" border="0" style="margin-bottom:14px;">
                       <tr>
-                        <td width="28" valign="top" style="font-size:20px;">🕒</td>
-                        <td style="font-size:15px; color:#111827; line-height:24px;">
-                          <strong>Saat:</strong> 16:00 – 20:00
+                        <td width="38" valign="top" style="font-size:24px;">🕒</td>
+                        <td style="font-size:17px; color:#111827; line-height:28px;">
+                          <strong style="color:#B91C1C;">Saat:</strong> 16:00 – 20:00
                         </td>
                       </tr>
                     </table>
 
                     <table role="presentation" width="100%" cellspacing="0" cellpadding="0" border="0">
                       <tr>
-                        <td width="28" valign="top" style="font-size:20px;">📍</td>
-                        <td style="font-size:15px; color:#111827; line-height:24px;">
-                          <strong>Konum:</strong> Y-110, Yaşar Üniversitesi
+                        <td width="38" valign="top" style="font-size:24px;">📍</td>
+                        <td style="font-size:17px; color:#111827; line-height:28px;">
+                          <strong style="color:#B91C1C;">Konum:</strong> Y-110, Yaşar Üniversitesi
                         </td>
                       </tr>
                     </table>
-
                   </td>
                 </tr>
               </table>
 
-             
               <table role="presentation" width="100%" cellspacing="0" cellpadding="0" border="0"
-                     class="event-details-box" style="margin-bottom:14px;">
+                     class="event-details-box" style="margin-bottom:24px;">
                 <tr>
-                  <td style="padding:20px 20px;">
-                    <p class="section-title" style="margin:0 0 14px 0;">🎤 Oturumlar & Konuşmacılar</p>
+                  <td style="padding:22px 22px;">
+                    <p class="section-title">🎤 Oturumlar & Konuşmacılar</p>
 
-                   
-                    <table role="presentation" width="100%" cellspacing="0" cellpadding="0" border="0" style="margin-bottom:14px;">
+                    <table role="presentation" width="100%" cellspacing="0" cellpadding="0" border="0" style="margin-bottom:16px;">
                       <tr>
-                        <td width="86" valign="top" align="center" style="padding-right:14px;">
-                          <img
-                            src="https://raw.githubusercontent.com/GDG-Yasar-Software-Team/mail-assets/main/ai-talks-25/halil_ibrahim_y%C4%B1ld%C4%B1r%C4%B1m.png"
-                            alt="Halil İbrahim Yıldırım"
-                            width="72" height="72"
-                            class="speaker-photo"
-                            style="display:block; width:72px; height:72px;"
-                          />
+                        <td width="92" valign="top" align="center" style="padding-right:14px;">
+                          <img src="https://raw.githubusercontent.com/GDG-Yasar-Software-Team/mail-assets/main/ai-talks-25/Adobe%20Express%20-%20file.png" width="80" height="80" class="speaker-photo" />
                         </td>
-                        <td valign="middle" style="font-size:14.5px; color:#111827; line-height:22px;">
-                          <strong>1. Oturum:</strong> Makine Öğrenimini Büyük Ölçekte Operasyonelleştirme<br />
-                          <span class="muted">16:00–16:45 · Y-110</span><br />
-                          <span class="muted">Konuşmacı: Halil İbrahim Yıldırım</span>
+                        <td valign="middle" style="font-size:17px; color:#111827; line-height:24px;">
+                          <strong style="color:#B91C1C;">1. Oturum:</strong> Makine Öğrenimini Büyük Ölçekte Operasyonelleştirme<br />
+                          <span class="muted">16:00–16:45 · Konuşmacı: Halil İbrahim Yıldırım</span>
                         </td>
                       </tr>
                     </table>
 
-                    <hr style="border:none; border-top:1px solid #eee; margin:12px 0;" />
+                   <hr style="border:none; border-top:1px solid #fee2e2; margin:14px 0;" />
 
-                   
-                    <table role="presentation" width="100%" cellspacing="0" cellpadding="0" border="0" style="margin-bottom:14px;">
+                    <table role="presentation" width="100%" cellspacing="0" cellpadding="0" border="0" style="margin-bottom:16px;">
                       <tr>
-                        <td width="86" valign="top" align="center" style="padding-right:14px;">
-                          <img
-                            src="https://raw.githubusercontent.com/GDG-Yasar-Software-Team/mail-assets/main/ai-talks-25/busra_korkmaz.png"
-                            alt="Büşra Korkmaz"
-                            width="72" height="72"
-                            class="speaker-photo"
-                            style="display:block; width:72px; height:72px;"
-                          />
+                        <td width="92" valign="top" align="center" style="padding-right:14px;">
+                          <img src="https://raw.githubusercontent.com/GDG-Yasar-Software-Team/mail-assets/main/ai-talks-25/Adobe%20Express%20-%20file%20(1).png
+" width="80" height="80" class="speaker-photo" />
                         </td>
-                        <td valign="middle" style="font-size:14.5px; color:#111827; line-height:22px;">
-                          <strong>2. Oturum:</strong> Gerçek Zamanlı AI Mimarileri<br />
-                          <span class="muted">17:00–17:45 · Y-110</span><br />
-                          <span class="muted">Konuşmacı: Büşra Korkmaz</span>
+                        <td valign="middle" style="font-size:17px; color:#111827; line-height:24px;">
+                          <strong style="color:#B91C1C;">2. Oturum:</strong> Gerçek Zamanlı AI Mimarileri<br />
+                          <span class="muted">17:00–17:45 · Konuşmacı: Büşra Korkmaz</span>
                         </td>
                       </tr>
                     </table>
 
-                    <hr style="border:none; border-top:1px solid #eee; margin:12px 0;" />
+                    <hr style="border:none; border-top:1px solid #fee2e2; margin:14px 0;" />
 
-                    
-                    <table role="presentation" width="100%" cellspacing="0" cellpadding="0" border="0" style="margin-bottom:14px;">
+                    <table role="presentation" width="100%" cellspacing="0" cellpadding="0" border="0" style="margin-bottom:16px;">
                       <tr>
-                        <td width="86" valign="top" align="center" style="padding-right:14px;">
-                          <img
-                            src="https://raw.githubusercontent.com/GDG-Yasar-Software-Team/mail-assets/main/ai-talks-25/g%C3%BCrkan_y%C4%B1lmaz.png"
-                            alt="Gürkan Yılmaz"
-                            width="72" height="72"
-                            class="speaker-photo"
-                            style="display:block; width:72px; height:72px;"
-                          />
+                        <td width="92" valign="top" align="center" style="padding-right:14px;">
+                          <img src="https://raw.githubusercontent.com/GDG-Yasar-Software-Team/mail-assets/main/ai-talks-25/Adobe%20Express%20-%20file%20(2).png" width="80" height="80" class="speaker-photo" />
                         </td>
-                        <td valign="middle" style="font-size:14.5px; color:#111827; line-height:22px;">
-                          <strong>3. Oturum:</strong> Kişiselleştirilmiş Öneri Sistemleri<br />
-                          <span class="muted">18:15–19:00 · Y-110</span><br />
-                          <span class="muted">Konuşmacı: Gürkan Yılmaz</span>
+                        <td valign="middle" style="font-size:17px; color:#111827; line-height:24px;">
+                          <strong style="color:#B91C1C;">3. Oturum:</strong> Kişiselleştirilmiş Öneri Sistemleri<br />
+                          <span class="muted">18:15–19:00 · Konuşmacı: Gürkan Yılmaz</span>
                         </td>
                       </tr>
                     </table>
 
-                    <hr style="border:none; border-top:1px solid #eee; margin:12px 0;" />
+                    <hr style="border:none; border-top:1px solid #fee2e2; margin:14px 0;" />
 
                     <table role="presentation" width="100%" cellspacing="0" cellpadding="0" border="0">
                       <tr>
-                        <td width="86" valign="top" align="center" style="padding-right:14px;">
-                          <img
-                            src="https://raw.githubusercontent.com/GDG-Yasar-Software-Team/mail-assets/main/ai-talks-25/oguzhan_nejat_karabas.png"
-                            alt="Oğuzhan Nejat Karabaş"
-                            width="72" height="72"
-                            class="speaker-photo"
-                            style="display:block; width:72px; height:72px;"
-                          />
+                        <td width="92" valign="top" align="center" style="padding-right:14px;">
+                          <img src="https://raw.githubusercontent.com/GDG-Yasar-Software-Team/mail-assets/main/ai-talks-25/oguzhan_nejat.jpg
+" width="80" height="80" class="speaker-photo" />
                         </td>
-                        <td valign="middle" style="font-size:14.5px; color:#111827; line-height:22px;">
-                          <strong>4. Oturum:</strong> Kurumsal GenAI: RAG, MLOps ve Ajan Sistemleri<br />
-                          <span class="muted">19:15–20:00 · Y-110</span><br />
-                          <span class="muted">Konuşmacı: Oğuzhan Nejat Karabaş</span>
+                        <td valign="middle" style="font-size:17px; color:#111827; line-height:24px;">
+                          <strong style="color:#B91C1C;">4. Oturum:</strong> Kurumsal GenAI: RAG, MLOps ve Ajan Sistemleri<br />
+                          <span class="muted">19:15–20:00 · Konuşmacı: Oğuzhan Nejat Karabaş</span>
                         </td>
                       </tr>
                     </table>
@@ -260,34 +214,18 @@
                 </tr>
               </table>
 
-             
-                <table role="presentation" width="100%" cellspacing="0" cellpadding="0" border="0" style="margin-bottom:18px;">               
-                <tr>
-                 <td style="padding:2px 2px 0 2px;">                     
-                         <p class="note-line">🎓 Sertifikalı Etkinlik</p>
-                  </td>
-                </tr>
+              <table role="presentation" width="100%" cellspacing="0" cellpadding="0" border="0" style="margin-bottom:18px;">                
+                <tr><td style="padding:6px 0;"><p class="note-line">🎓 Sertifikalı Etkinlik</p></td></tr>
+                <tr><td style="padding:6px 0;"><p class="note-line">📌 Not: Etkinlik dili Türkçe’dir.</p></td></tr>
               </table>
 
-              
-            
-              <table role="presentation" width="100%" cellspacing="0" cellpadding="0" border="0" style="margin-bottom:18px;">
-                <tr>
-                  <td style="padding:2px 2px 0 2px;">
-                    <p class="note-line">📌 Not: Etkinlik dili Türkçe’dir.</p>
-                  </td>
-                </tr>
-              </table>
-
-         
               <table role="presentation" width="100%" cellspacing="0" cellpadding="0" border="0">
                 <tr>
-                  <td align="center" style="padding:6px 0 4px 0;">
-                    <a
-                      href="https://docs.google.com/forms/d/e/1FAIpQLSfWVlRu7jUv6dkuM0CABl5WBMKqDCo3-RJmkx2eVqsCJKvPBg/viewform"
-                      style="display:inline-block; padding:10px 22px; background-color:#B91C1C; color:#ffffff; text-decoration:none; border-radius:8px; font-size:14px; font-weight:700; text-transform:uppercase; letter-spacing:0.2px;"
-                    >
-                      Kayıt Ol
+                  <td align="center" style="padding:0;">
+
+                    <a href="https://docs.google.com/forms/d/e/1FAIpQLSfWVlRu7jUv6dkuM0CABl5WBMKqDCo3-RJmkx2eVqsCJKvPBg/viewform"
+                       style="display:inline-block; padding:18px 50px; background-color:#B91C1C; color:#ffffff; text-decoration:none; border-radius:10px; font-size:18px; font-weight:700; text-transform:uppercase; letter-spacing:1px; box-shadow:0 4px 15px rgba(185, 28, 28, 0.3);">
+                      Hemen Kayıt Ol
                     </a>
                   </td>
                 </tr>
@@ -296,32 +234,12 @@
             </td>
           </tr>
 
-          
           <tr>
-            <td style="padding:24px 40px 28px 40px; background-color:#f0f2f5; border-top:1px solid #e5e7eb;">
-              <table role="presentation" width="100%" cellspacing="0" cellpadding="0" border="0" style="margin-bottom:14px;">
-                <tr>
-                  <td align="center">
-                    <a href="https://instagram.com/yu.gdgoncampus" style="display:inline-block; margin:0 10px; text-decoration:none;">
-                      <img
-                        src="https://upload.wikimedia.org/wikipedia/commons/a/a5/Instagram_icon.png"
-                        alt="Instagram"
-                        width="30" height="30"
-                        style="display:block;"
-                      />
-                    </a>
-                  </td>
-                </tr>
-              </table>
+            <td style="padding:35px 40px; background-color:#f8f9fa; border-top:2px solid #B91C1C;">
 
-              <p style="margin:0 0 8px 0; font-size:13px; line-height:20px; color:#6b7280; text-align:center;">
-                GDG on Campus · Yaşar University
-              </p>
-              <p style="margin:0; font-size:13px; line-height:20px; color:#6b7280; text-align:center;">
-                İletişim:
-                <a href="mailto:gdgoncampus.yu@gmail.com" style="color:#E91E63; text-decoration:none; font-weight:700;">
-                  gdgoncampus.yu@gmail.com
-                </a>
+              <p style="margin:0 0 10px 0; font-size:15px; color:#6b7280; text-align:center;">GDG on Campus · Yaşar University</p>
+              <p style="margin:0; font-size:15px; color:#6b7280; text-align:center;">
+                İletişim: <a href="mailto:gdgoncampus.yu@gmail.com" style="color:#B91C1C; text-decoration:none; font-weight:700;">gdgoncampus.yu@gmail.com</a>
               </p>
             </td>
           </tr>


### PR DESCRIPTION
This PR adds the AI TALKS'25 HTML email template and organizes event assets under a dedicated folder.

## What does this PR do?
- Adds a new responsive HTML email template for **AI TALKS’25** (banner, event details, agenda/speakers, CTA, footer).
- Organizes assets in `ai-talks-25/` to keep event files separated and reusable.
- Fixes image rendering by switching to **raw GitHub URLs** for email clients.
- Improves speaker avatars (consistent circular crop, size, and alignment).
- Updates CTA button (smaller size, better fit on mobile clients).
- Reduces spacing/overflows so content fits better in Mailtrap/mobile previews.

## Assets used
Located under: `ai-talks-25/`
- Banner: `ai-talks-25ai-talks-email-banner.png`
- Speakers:
  - `halil_ibrahim_yıldırım.png`
  - `busra_korkmaz.png`
  - `gürkan_yılmaz.png`
  - `oguzhan_nejat_karabas.png`

## Related Issue
Closes #43 

## Checklist
- [x] Code follows project conventions
- [x] Tested in Mailtrap (mobile/desktop preview)
- [x] Added @seberatolmez or @dogukaurker as reviewers
