### PR TITLE
fix(ma): Update image links in Design Patterns event email template

### DIFF
--- a/scripts/mails/2026-02-12-design-patterns.html
+++ b/scripts/mails/2026-02-12-design-patterns.html
@@ -70,7 +70,7 @@
           
           <tr>
             <td align="center" style="padding: 0; overflow: hidden; height: 200px; line-height: 0; position: relative;">
-              <img src="https://raw.githubusercontent.com/GDG-Yasar-Software-Team/mail-assets/feature/email-template/desing-patters/banner.gif" width="600" style="display: block; width: 100%; max-width: 600px; height: auto; border: 0; margin-top: -50px; margin-bottom: -60px;" alt="GDG Design Patterns Event Banner" />
+              <img src="https://raw.githubusercontent.com/GDG-Yasar-Software-Team/mail-assets/main/design-patterns/banner.gif" width="600" style="display: block; width: 100%; max-width: 600px; height: auto; border: 0; margin-top: -50px; margin-bottom: -60px;" alt="GDG Design Patterns Event Banner" />
               <div style="width: 100%; height: 20px; background-color: #ffffff; display: block; margin-top: -20px;"></div>
             </td>
           </tr>
@@ -100,7 +100,7 @@
                     <table role="presentation" cellpadding="0" cellspacing="0" border="0">
                       <tr>
                         <td align="center" style="width: 210px; height: 210px; border-radius: 50%; background-color: #FF6000; padding: 6px;">
-                          <img src="https://raw.githubusercontent.com/GDG-Yasar-Software-Team/mail-assets/feature/email-template/desing-patters/batuhan-g%C3%BCng%C3%B6r.jpg" width="208" height="208" style="display: block; width: 208px; height: 208px; border-radius: 50%; border: 0;" alt="Batuhan Güngör" />
+                          <img src="https://raw.githubusercontent.com/GDG-Yasar-Software-Team/mail-assets/main/design-patterns/batuhan-gungor.jpg" width="208" height="208" style="display: block; width: 208px; height: 208px; border-radius: 50%; border: 0;" alt="Batuhan Güngör" />
                         </td>
                       </tr>
                     </table>
@@ -179,7 +179,7 @@
               <table border="0" cellpadding="0" cellspacing="0">
                 <tr>
                   <td style="vertical-align: middle; padding-right: 12px;">
-                    <img src="https://raw.githubusercontent.com/GDG-Yasar-Software-Team/mail-assets/feature/email-template/desing-patters/gdg-logo.png" alt="GDG Logo" width="47" height="47" style="display: block; border: 0;">
+                    <img src="https://raw.githubusercontent.com/GDG-Yasar-Software-Team/mail-assets/main/design-patterns/gdg-logo.png" alt="GDG Logo" width="47" height="47" style="display: block; border: 0;">
                   </td>
                   <td style="vertical-align: middle;">
                     <div style="font-family: 'Source Sans 3', Roboto, Arial, Helvetica, sans-serif; font-size: 15px; font-weight: 600; color: #000000; line-height: 20px;">Google Developer Groups</div>


### PR DESCRIPTION
## What does this PR do?

Fixes broken images in the Design Patterns event email by updating
asset URLs after renaming image files and switching to raw GitHub links.

## Related Issue

Closes #

## Checklist

- [ ] Code follows project conventions
- [ ] I tested my changes locally
- [ ] Linting passes
- [ ] I added @seberatolmez or @dogukanurker as reviewers
