### PR TITLE
feat(ev): add event repository and service layers

### DIFF
--- a/services/event/app/repositories/event_repository.py
+++ b/services/event/app/repositories/event_repository.py
@@ -1,0 +1,119 @@
+from datetime import datetime, timezone
+
+from bson import ObjectId
+
+from app.config import settings
+from app.db.mongodb import MongoDB
+from app.models.event import EventCreate, EventInDB, EventUpdate
+from app.utils.logger import logger
+
+
+class EventNotFoundError(Exception):
+    """Raised when an event is not found."""
+
+    pass
+
+
+class EventRepository:
+    @classmethod
+    def _get_collection(cls):
+        return MongoDB.get_db()[settings.EVENTS_COLLECTION]
+
+    @classmethod
+    async def create(cls, event: EventCreate) -> str:
+        """Create a new event. Returns the inserted ID as string."""
+        collection = cls._get_collection()
+
+        doc = {
+            "title": event.title,
+            "description": event.description,
+            "date": event.date,
+            "place": event.place,
+            "speakers": [speaker.model_dump() for speaker in event.speakers],
+            "image_url": event.image_url,
+            "created_at": datetime.now(timezone.utc),
+            "updated_at": None,
+        }
+
+        result = await collection.insert_one(doc)
+        event_id = str(result.inserted_id)
+
+        logger.info("Event created", event_id=event_id, title=event.title)
+        return event_id
+
+    @classmethod
+    async def get_by_id(cls, event_id: str) -> EventInDB | None:
+        """Fetch an event by ID. Returns None for invalid or missing IDs."""
+        collection = cls._get_collection()
+
+        if not ObjectId.is_valid(event_id):
+            return None
+
+        doc = await collection.find_one({"_id": ObjectId(event_id)})
+        if doc is None:
+            return None
+
+        return EventInDB.model_validate(doc)
+
+    @classmethod
+    async def update(cls, event_id: str, update: EventUpdate) -> EventInDB:
+        """Update an event with partial data. Raises EventNotFoundError if not found."""
+        collection = cls._get_collection()
+
+        if not ObjectId.is_valid(event_id):
+            raise EventNotFoundError(f"Invalid event ID: {event_id}")
+
+        update_data = update.model_dump(exclude_unset=True)
+        if not update_data:
+            event = await cls.get_by_id(event_id)
+            if event is None:
+                raise EventNotFoundError(f"Event not found: {event_id}")
+            return event
+
+        if "speakers" in update_data and update_data["speakers"] is not None:
+            update_data["speakers"] = [
+                speaker.model_dump() if hasattr(speaker, "model_dump") else speaker
+                for speaker in update_data["speakers"]
+            ]
+
+        update_data["updated_at"] = datetime.now(timezone.utc)
+
+        result = await collection.update_one(
+            {"_id": ObjectId(event_id)},
+            {"$set": update_data},
+        )
+
+        if result.matched_count == 0:
+            raise EventNotFoundError(f"Event not found: {event_id}")
+
+        updated_event = await cls.get_by_id(event_id)
+        logger.info("Event updated", event_id=event_id)
+        return updated_event
+
+    @classmethod
+    async def delete(cls, event_id: str) -> None:
+        """Delete an event by ID. Raises EventNotFoundError if not found."""
+        collection = cls._get_collection()
+
+        if not ObjectId.is_valid(event_id):
+            raise EventNotFoundError(f"Invalid event ID: {event_id}")
+
+        result = await collection.delete_one({"_id": ObjectId(event_id)})
+
+        if result.deleted_count == 0:
+            raise EventNotFoundError(f"Event not found: {event_id}")
+
+        logger.info("Event deleted", event_id=event_id)
+
+    @classmethod
+    async def list_events(cls, limit: int = 20, offset: int = 0) -> list[EventInDB]:
+        """List events sorted by created_at descending."""
+        collection = cls._get_collection()
+
+        cursor = collection.find().sort("created_at", -1).skip(offset).limit(limit)
+
+        events = []
+        async for doc in cursor:
+            events.append(EventInDB.model_validate(doc))
+
+        return events

--- a/services/event/app/services/event_service.py
+++ b/services/event/app/services/event_service.py
@@ -1,0 +1,43 @@
+from datetime import datetime, timezone
+
+from app.models.event import EventCreate, EventResponse, EventUpdate
+from app.repositories.event_repository import EventRepository
+from app.utils.logger import logger
+
+
+class EventService:
+    @classmethod
+    async def create_event(cls, data: EventCreate) -> str:
+        """Create a new event after validating the event date is in the future."""
+        if data.date <= datetime.now(timezone.utc):
+            raise ValueError("Event date must be in the future")
+
+        logger.info("Creating event", title=data.title, date=str(data.date))
+        return await EventRepository.create(data)
+
+    @classmethod
+    async def get_event_by_id(cls, event_id: str) -> EventResponse | None:
+        """Get an event by ID. Returns None if not found."""
+        db_event = await EventRepository.get_by_id(event_id)
+        if db_event is None:
+            return None
+        return EventResponse.from_db(db_event)
+
+    @classmethod
+    async def update_event(cls, event_id: str, update: EventUpdate) -> EventResponse:
+        """Update an event. Raises EventNotFoundError if not found."""
+        db_event = await EventRepository.update(event_id, update)
+        logger.info("Event updated via service", event_id=event_id)
+        return EventResponse.from_db(db_event)
+
+    @classmethod
+    async def delete_event(cls, event_id: str) -> None:
+        """Delete an event. Raises EventNotFoundError if not found."""
+        await EventRepository.delete(event_id)
+        logger.info("Event deleted via service", event_id=event_id)
+
+    @classmethod
+    async def list_events(cls, limit: int = 20, offset: int = 0) -> list[EventResponse]:
+        """List events sorted by most recent first."""
+        db_events = await EventRepository.list_events(limit=limit, offset=offset)
+        return [EventResponse.from_db(event) for event in db_events]

--- a/services/event/tests/conftest.py
+++ b/services/event/tests/conftest.py
@@ -1,13 +1,17 @@
 """Pytest fixtures for event service tests."""
 
 from collections.abc import AsyncGenerator, Generator
+from datetime import datetime, timezone
+from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from bson import ObjectId
 from fastapi.testclient import TestClient
 from httpx import ASGITransport, AsyncClient
 
 from app.config import Settings
+from app.models.event import EventCreate, Speaker
 
 # Test token constant
 TEST_API_TOKEN = "test-api-token-12345"
@@ -33,7 +37,8 @@ def mock_settings():
     with patch("app.config.settings", test_settings):
         with patch("app.config.get_settings", return_value=test_settings):
             with patch("app.db.mongodb.settings", test_settings):
-                yield test_settings
+                with patch("app.repositories.event_repository.settings", test_settings):
+                    yield test_settings
 
 
 @pytest.fixture
@@ -64,6 +69,66 @@ def mock_mongodb():
                 "db": mock_db,
                 "events": events_collection,
             }
+
+
+@pytest.fixture
+def sample_event_data() -> EventCreate:
+    """Sample EventCreate instance for testing."""
+    return EventCreate(
+        title="GDG DevFest 2025",
+        description="Annual developer festival.",
+        date=datetime(2099, 11, 15, 10, 0, 0, tzinfo=timezone.utc),
+        place="Yaşar University",
+        speakers=[Speaker(name="Jane Doe", title="Engineer", company="Google")],
+        image_url="https://example.com/image.jpg",
+    )
+
+
+@pytest.fixture
+def sample_event_doc() -> dict[str, Any]:
+    """Sample event document in DB format."""
+    return {
+        "_id": ObjectId("507f1f77bcf86cd799439011"),
+        "title": "GDG DevFest 2025",
+        "description": "Annual developer festival.",
+        "date": datetime(2099, 11, 15, 10, 0, 0, tzinfo=timezone.utc),
+        "place": "Yaşar University",
+        "speakers": [{"name": "Jane Doe", "title": "Engineer", "company": "Google"}],
+        "image_url": "https://example.com/image.jpg",
+        "created_at": datetime(2025, 1, 1, 0, 0, 0, tzinfo=timezone.utc),
+        "updated_at": None,
+    }
+
+
+@pytest.fixture
+def sample_event_docs() -> list[dict[str, Any]]:
+    """Multiple sample event documents in DB format."""
+    return [
+        {
+            "_id": ObjectId("507f1f77bcf86cd799439011"),
+            "title": "GDG DevFest 2025",
+            "description": "Annual developer festival.",
+            "date": datetime(2099, 11, 15, 10, 0, 0, tzinfo=timezone.utc),
+            "place": "Yaşar University",
+            "speakers": [],
+            "image_url": None,
+            "created_at": datetime(2025, 1, 1, 0, 0, 0, tzinfo=timezone.utc),
+            "updated_at": None,
+        },
+        {
+            "_id": ObjectId("507f1f77bcf86cd799439012"),
+            "title": "Flutter Workshop",
+            "description": "Hands-on Flutter workshop.",
+            "date": datetime(2099, 12, 1, 14, 0, 0, tzinfo=timezone.utc),
+            "place": "Engineering Building",
+            "speakers": [
+                {"name": "John Smith", "title": "Developer", "company": "Flutter"}
+            ],
+            "image_url": "https://example.com/flutter.jpg",
+            "created_at": datetime(2025, 2, 1, 0, 0, 0, tzinfo=timezone.utc),
+            "updated_at": None,
+        },
+    ]
 
 
 @pytest.fixture

--- a/services/event/tests/test_event_repository.py
+++ b/services/event/tests/test_event_repository.py
@@ -1,0 +1,268 @@
+"""Tests for event repository."""
+
+from datetime import datetime
+from unittest.mock import MagicMock
+
+import pytest
+from bson import ObjectId
+
+from app.repositories.event_repository import (
+    EventNotFoundError,
+    EventRepository,
+)
+from tests.conftest import create_async_cursor
+
+
+class TestCreate:
+    """Tests for EventRepository.create()."""
+
+    async def test_inserts_document_and_returns_id(
+        self, mock_mongodb, sample_event_data
+    ):
+        """Create inserts a document and returns the inserted ID as string."""
+        expected_id = ObjectId("507f1f77bcf86cd799439011")
+        mock_mongodb["events"].insert_one.return_value = MagicMock(
+            inserted_id=expected_id
+        )
+
+        event_id = await EventRepository.create(sample_event_data)
+
+        assert event_id == str(expected_id)
+        assert isinstance(event_id, str)
+        mock_mongodb["events"].insert_one.assert_called_once()
+
+    async def test_document_structure(self, mock_mongodb, sample_event_data):
+        """Create inserts a document with correct field structure."""
+        mock_mongodb["events"].insert_one.return_value = MagicMock(
+            inserted_id=ObjectId()
+        )
+
+        await EventRepository.create(sample_event_data)
+
+        call_args = mock_mongodb["events"].insert_one.call_args[0][0]
+        assert call_args["title"] == "GDG DevFest 2025"
+        assert call_args["description"] == "Annual developer festival."
+        assert call_args["place"] == "Yaşar University"
+        assert call_args["image_url"] == "https://example.com/image.jpg"
+        assert len(call_args["speakers"]) == 1
+        assert call_args["speakers"][0]["name"] == "Jane Doe"
+
+    async def test_sets_timestamps(self, mock_mongodb, sample_event_data):
+        """Create sets created_at and updated_at=None."""
+        mock_mongodb["events"].insert_one.return_value = MagicMock(
+            inserted_id=ObjectId()
+        )
+
+        await EventRepository.create(sample_event_data)
+
+        call_args = mock_mongodb["events"].insert_one.call_args[0][0]
+        assert isinstance(call_args["created_at"], datetime)
+        assert call_args["updated_at"] is None
+
+    async def test_speakers_serialized_as_dicts(self, mock_mongodb, sample_event_data):
+        """Create serializes Speaker models to dicts."""
+        mock_mongodb["events"].insert_one.return_value = MagicMock(
+            inserted_id=ObjectId()
+        )
+
+        await EventRepository.create(sample_event_data)
+
+        call_args = mock_mongodb["events"].insert_one.call_args[0][0]
+        assert isinstance(call_args["speakers"][0], dict)
+        assert call_args["speakers"][0] == {
+            "name": "Jane Doe",
+            "title": "Engineer",
+            "company": "Google",
+        }
+
+
+class TestGetById:
+    """Tests for EventRepository.get_by_id()."""
+
+    async def test_returns_event_when_found(self, mock_mongodb, sample_event_doc):
+        """get_by_id returns EventInDB when document exists."""
+        mock_mongodb["events"].find_one.return_value = sample_event_doc
+
+        event = await EventRepository.get_by_id("507f1f77bcf86cd799439011")
+
+        assert event is not None
+        assert str(event.id) == "507f1f77bcf86cd799439011"
+        assert event.title == "GDG DevFest 2025"
+
+    async def test_returns_none_when_not_found(self, mock_mongodb):
+        """get_by_id returns None when document does not exist."""
+        mock_mongodb["events"].find_one.return_value = None
+
+        event = await EventRepository.get_by_id("507f1f77bcf86cd799439011")
+
+        assert event is None
+
+    async def test_returns_none_for_invalid_id(self, mock_mongodb):
+        """get_by_id returns None for invalid ObjectId string."""
+        event = await EventRepository.get_by_id("invalid-id")
+
+        assert event is None
+        mock_mongodb["events"].find_one.assert_not_called()
+
+
+class TestUpdate:
+    """Tests for EventRepository.update()."""
+
+    async def test_updates_fields_and_returns_event(
+        self, mock_mongodb, sample_event_doc
+    ):
+        """Update applies $set and returns updated EventInDB."""
+        from app.models.event import EventUpdate
+
+        updated_doc = {**sample_event_doc, "title": "Updated Title"}
+        mock_mongodb["events"].update_one.return_value = MagicMock(matched_count=1)
+        mock_mongodb["events"].find_one.return_value = updated_doc
+
+        update = EventUpdate(title="Updated Title")
+        result = await EventRepository.update("507f1f77bcf86cd799439011", update)
+
+        assert result.title == "Updated Title"
+        mock_mongodb["events"].update_one.assert_called_once()
+
+    async def test_sets_updated_at(self, mock_mongodb, sample_event_doc):
+        """Update sets updated_at timestamp."""
+        from app.models.event import EventUpdate
+
+        mock_mongodb["events"].update_one.return_value = MagicMock(matched_count=1)
+        mock_mongodb["events"].find_one.return_value = sample_event_doc
+
+        update = EventUpdate(title="New Title")
+        await EventRepository.update("507f1f77bcf86cd799439011", update)
+
+        call_args = mock_mongodb["events"].update_one.call_args[0][1]
+        assert "updated_at" in call_args["$set"]
+        assert isinstance(call_args["$set"]["updated_at"], datetime)
+
+    async def test_raises_not_found_for_missing_event(self, mock_mongodb):
+        """Update raises EventNotFoundError when matched_count is 0."""
+        from app.models.event import EventUpdate
+
+        mock_mongodb["events"].update_one.return_value = MagicMock(matched_count=0)
+
+        update = EventUpdate(title="New Title")
+        with pytest.raises(EventNotFoundError):
+            await EventRepository.update("507f1f77bcf86cd799439011", update)
+
+    async def test_raises_not_found_for_invalid_id(self, mock_mongodb):
+        """Update raises EventNotFoundError for invalid ObjectId."""
+        from app.models.event import EventUpdate
+
+        update = EventUpdate(title="New Title")
+        with pytest.raises(EventNotFoundError):
+            await EventRepository.update("invalid-id", update)
+
+    async def test_empty_update_returns_current_event(
+        self, mock_mongodb, sample_event_doc
+    ):
+        """Update with no fields returns the current event unchanged."""
+        from app.models.event import EventUpdate
+
+        mock_mongodb["events"].find_one.return_value = sample_event_doc
+
+        update = EventUpdate()
+        result = await EventRepository.update("507f1f77bcf86cd799439011", update)
+
+        assert result.title == "GDG DevFest 2025"
+        mock_mongodb["events"].update_one.assert_not_called()
+
+    async def test_empty_update_raises_not_found_for_missing(self, mock_mongodb):
+        """Update with no fields raises EventNotFoundError if event doesn't exist."""
+        from app.models.event import EventUpdate
+
+        mock_mongodb["events"].find_one.return_value = None
+
+        update = EventUpdate()
+        with pytest.raises(EventNotFoundError):
+            await EventRepository.update("507f1f77bcf86cd799439011", update)
+
+    async def test_updates_speakers(self, mock_mongodb, sample_event_doc):
+        """Update serializes speakers list correctly."""
+        from app.models.event import EventUpdate, Speaker
+
+        updated_doc = {
+            **sample_event_doc,
+            "speakers": [
+                {"name": "New Speaker", "title": "CTO", "company": "StartupX"}
+            ],
+        }
+        mock_mongodb["events"].update_one.return_value = MagicMock(matched_count=1)
+        mock_mongodb["events"].find_one.return_value = updated_doc
+
+        update = EventUpdate(
+            speakers=[Speaker(name="New Speaker", title="CTO", company="StartupX")]
+        )
+        result = await EventRepository.update("507f1f77bcf86cd799439011", update)
+
+        assert len(result.speakers) == 1
+        assert result.speakers[0].name == "New Speaker"
+
+
+class TestDelete:
+    """Tests for EventRepository.delete()."""
+
+    async def test_deletes_existing_event(self, mock_mongodb):
+        """Delete removes the document when it exists."""
+        mock_mongodb["events"].delete_one.return_value = MagicMock(deleted_count=1)
+
+        await EventRepository.delete("507f1f77bcf86cd799439011")
+
+        mock_mongodb["events"].delete_one.assert_called_once_with(
+            {"_id": ObjectId("507f1f77bcf86cd799439011")}
+        )
+
+    async def test_raises_not_found_when_deleted_count_zero(self, mock_mongodb):
+        """Delete raises EventNotFoundError when deleted_count is 0."""
+        mock_mongodb["events"].delete_one.return_value = MagicMock(deleted_count=0)
+
+        with pytest.raises(EventNotFoundError):
+            await EventRepository.delete("507f1f77bcf86cd799439011")
+
+    async def test_raises_not_found_for_invalid_id(self, mock_mongodb):
+        """Delete raises EventNotFoundError for invalid ObjectId."""
+        with pytest.raises(EventNotFoundError):
+            await EventRepository.delete("invalid-id")
+
+        mock_mongodb["events"].delete_one.assert_not_called()
+
+
+class TestListEvents:
+    """Tests for EventRepository.list_events()."""
+
+    async def test_returns_events_list(self, mock_mongodb, sample_event_docs):
+        """list_events returns list of EventInDB models."""
+        mock_mongodb["events"].find.return_value = create_async_cursor(
+            sample_event_docs
+        )
+
+        events = await EventRepository.list_events()
+
+        assert len(events) == 2
+        assert events[0].title == "GDG DevFest 2025"
+        assert events[1].title == "Flutter Workshop"
+
+    async def test_returns_empty_list(self, mock_mongodb):
+        """list_events returns empty list when no events exist."""
+        mock_mongodb["events"].find.return_value = create_async_cursor([])
+
+        events = await EventRepository.list_events()
+
+        assert events == []
+
+    async def test_applies_sort_skip_limit(self, mock_mongodb):
+        """list_events calls sort, skip, and limit on the cursor."""
+        cursor_mock = MagicMock()
+        cursor_mock.sort.return_value = cursor_mock
+        cursor_mock.skip.return_value = cursor_mock
+        cursor_mock.limit.return_value = create_async_cursor([])
+        mock_mongodb["events"].find.return_value = cursor_mock
+
+        await EventRepository.list_events(limit=10, offset=5)
+
+        cursor_mock.sort.assert_called_once_with("created_at", -1)
+        cursor_mock.skip.assert_called_once_with(5)
+        cursor_mock.limit.assert_called_once_with(10)

--- a/services/event/tests/test_event_service.py
+++ b/services/event/tests/test_event_service.py
@@ -1,0 +1,211 @@
+"""Tests for event service."""
+
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from bson import ObjectId
+
+from app.models.event import EventCreate, EventInDB, EventUpdate
+from app.repositories.event_repository import EventNotFoundError
+from app.services.event_service import EventService
+
+
+def _make_db_event(**kwargs) -> EventInDB:
+    """Helper to create an EventInDB with sensible defaults."""
+    defaults = {
+        "_id": ObjectId("507f1f77bcf86cd799439011"),
+        "title": "GDG DevFest 2025",
+        "description": "Annual developer festival.",
+        "date": datetime(2099, 11, 15, 10, 0, 0, tzinfo=timezone.utc),
+        "place": "Yaşar University",
+        "speakers": [],
+        "image_url": None,
+        "created_at": datetime(2025, 1, 1, 0, 0, 0, tzinfo=timezone.utc),
+        "updated_at": None,
+    }
+    defaults.update(kwargs)
+    return EventInDB(**defaults)
+
+
+class TestCreateEvent:
+    """Tests for EventService.create_event()."""
+
+    async def test_creates_event_with_future_date(self, mock_mongodb):
+        """create_event delegates to repository for a valid future date."""
+        with patch(
+            "app.services.event_service.EventRepository.create",
+            new_callable=AsyncMock,
+            return_value="507f1f77bcf86cd799439011",
+        ):
+            data = EventCreate(
+                title="GDG DevFest 2025",
+                description="Annual developer festival.",
+                date=datetime(2099, 11, 15, 10, 0, 0, tzinfo=timezone.utc),
+                place="Yaşar University",
+            )
+            event_id = await EventService.create_event(data)
+
+            assert event_id == "507f1f77bcf86cd799439011"
+
+    async def test_raises_value_error_for_past_date(self, mock_mongodb):
+        """create_event raises ValueError when event date is in the past."""
+        data = EventCreate(
+            title="Past Event",
+            description="Already happened.",
+            date=datetime(2020, 1, 1, 0, 0, 0, tzinfo=timezone.utc),
+            place="Somewhere",
+        )
+
+        with pytest.raises(ValueError, match="Event date must be in the future"):
+            await EventService.create_event(data)
+
+    async def test_delegates_to_repository(self, mock_mongodb):
+        """create_event calls EventRepository.create with the data."""
+        with patch(
+            "app.services.event_service.EventRepository.create",
+            new_callable=AsyncMock,
+            return_value="507f1f77bcf86cd799439011",
+        ) as mock_create:
+            data = EventCreate(
+                title="Workshop",
+                description="A workshop.",
+                date=datetime(2099, 6, 1, 10, 0, 0, tzinfo=timezone.utc),
+                place="Lab",
+            )
+            await EventService.create_event(data)
+
+            mock_create.assert_called_once_with(data)
+
+
+class TestGetEventById:
+    """Tests for EventService.get_event_by_id()."""
+
+    async def test_returns_event_response(self, mock_mongodb):
+        """get_event_by_id returns EventResponse when found."""
+        db_event = _make_db_event()
+
+        with patch(
+            "app.services.event_service.EventRepository.get_by_id",
+            new_callable=AsyncMock,
+            return_value=db_event,
+        ):
+            response = await EventService.get_event_by_id("507f1f77bcf86cd799439011")
+
+            assert response is not None
+            assert response.id == "507f1f77bcf86cd799439011"
+            assert response.title == "GDG DevFest 2025"
+
+    async def test_returns_none_when_not_found(self, mock_mongodb):
+        """get_event_by_id returns None when event doesn't exist."""
+        with patch(
+            "app.services.event_service.EventRepository.get_by_id",
+            new_callable=AsyncMock,
+            return_value=None,
+        ):
+            response = await EventService.get_event_by_id("507f1f77bcf86cd799439011")
+
+            assert response is None
+
+
+class TestUpdateEvent:
+    """Tests for EventService.update_event()."""
+
+    async def test_updates_and_returns_response(self, mock_mongodb):
+        """update_event delegates to repository and returns EventResponse."""
+        db_event = _make_db_event(title="Updated Title")
+
+        with patch(
+            "app.services.event_service.EventRepository.update",
+            new_callable=AsyncMock,
+            return_value=db_event,
+        ):
+            update = EventUpdate(title="Updated Title")
+            response = await EventService.update_event(
+                "507f1f77bcf86cd799439011", update
+            )
+
+            assert response.title == "Updated Title"
+            assert response.id == "507f1f77bcf86cd799439011"
+
+    async def test_propagates_not_found_error(self, mock_mongodb):
+        """update_event propagates EventNotFoundError from repository."""
+        with patch(
+            "app.services.event_service.EventRepository.update",
+            new_callable=AsyncMock,
+            side_effect=EventNotFoundError("Event not found"),
+        ):
+            update = EventUpdate(title="New Title")
+            with pytest.raises(EventNotFoundError):
+                await EventService.update_event("507f1f77bcf86cd799439011", update)
+
+
+class TestDeleteEvent:
+    """Tests for EventService.delete_event()."""
+
+    async def test_delegates_to_repository(self, mock_mongodb):
+        """delete_event calls EventRepository.delete."""
+        with patch(
+            "app.services.event_service.EventRepository.delete",
+            new_callable=AsyncMock,
+        ) as mock_delete:
+            await EventService.delete_event("507f1f77bcf86cd799439011")
+
+            mock_delete.assert_called_once_with("507f1f77bcf86cd799439011")
+
+    async def test_propagates_not_found_error(self, mock_mongodb):
+        """delete_event propagates EventNotFoundError from repository."""
+        with patch(
+            "app.services.event_service.EventRepository.delete",
+            new_callable=AsyncMock,
+            side_effect=EventNotFoundError("Event not found"),
+        ):
+            with pytest.raises(EventNotFoundError):
+                await EventService.delete_event("507f1f77bcf86cd799439011")
+
+
+class TestListEvents:
+    """Tests for EventService.list_events()."""
+
+    async def test_returns_list_of_event_responses(self, mock_mongodb):
+        """list_events returns list of EventResponse models."""
+        db_events = [
+            _make_db_event(),
+            _make_db_event(
+                _id=ObjectId("507f1f77bcf86cd799439012"),
+                title="Flutter Workshop",
+            ),
+        ]
+
+        with patch(
+            "app.services.event_service.EventRepository.list_events",
+            new_callable=AsyncMock,
+            return_value=db_events,
+        ):
+            responses = await EventService.list_events()
+
+            assert len(responses) == 2
+            assert responses[0].id == "507f1f77bcf86cd799439011"
+            assert responses[1].title == "Flutter Workshop"
+
+    async def test_returns_empty_list(self, mock_mongodb):
+        """list_events returns empty list when no events exist."""
+        with patch(
+            "app.services.event_service.EventRepository.list_events",
+            new_callable=AsyncMock,
+            return_value=[],
+        ):
+            responses = await EventService.list_events()
+
+            assert responses == []
+
+    async def test_passes_limit_and_offset(self, mock_mongodb):
+        """list_events forwards limit and offset to repository."""
+        with patch(
+            "app.services.event_service.EventRepository.list_events",
+            new_callable=AsyncMock,
+            return_value=[],
+        ) as mock_list:
+            await EventService.list_events(limit=10, offset=5)
+
+            mock_list.assert_called_once_with(limit=10, offset=5)


### PR DESCRIPTION
## What does this PR do?

Add EventRepository and EventService layers for the event service.

- `EventRepository` with CRUD operations (create, get_by_id, update, delete, list_events)
- `EventService` with business logic (future date validation)
- `EventNotFoundError` custom exception
- 33 unit tests (21 repository + 12 service), 100% coverage on new code

## Related Issue

Closes #101

## Checklist

- [x] Code follows project conventions
- [x] I tested my changes locally
- [x] Linting passes
- [x] I updated/added tests for my changes
- [x] I added @seberatolmez or @dogukanurker as reviewers